### PR TITLE
Fix apps loading

### DIFF
--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -41,8 +41,10 @@ UPSTREAM_APPS = (
 )
 
 # Project apps tested by jenkins (everything in apps/)
-PROJECT_APPS = filter(lambda f: f != '__init__.py',
-                      tuple(os.listdir(os.path.join('.', 'apps'))))
+APPS_DIR = os.path.join(PROJECT_ROOT, 'apps')
+PROJECT_APPS = tuple(['apps.' + aname
+                     for aname in os.listdir(APPS_DIR)
+                     if os.path.isdir(os.path.join(APPS_DIR, aname))])
 
 INSTALLED_APPS = UPSTREAM_APPS + PROJECT_APPS
 


### PR DESCRIPTION
Currently, one you add apps in the apps/ directory, you need to call them with 'apps.$app', that sucks. :-) The first commit solves this.

Also, if you get an **init**.pyc file, it will get taken as an app, the second commit fixes that. Maybe the function should only take directories instead of this workaround though.
